### PR TITLE
Widen camptocamp/systemd requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 0.2.2 < 0.3.0"
+      "version_requirement": ">= 0.2.2 < 1.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This library is compatible with later versions of `camptocamp/systemd`, so we can widen the version requirement to at least include all pre-1.0.0 versions (but it's still compatible with 1.0.0+ AFAIK).

![](https://ljdchost.com/z2YOaCT.gif)