### PR TITLE
Newer Mirror maker doesn't use zookeeper for consumer connection. Thi…

### DIFF
--- a/manifests/mirror/config.pp
+++ b/manifests/mirror/config.pp
@@ -22,8 +22,8 @@ class kafka::mirror::config(
   if $consumer_config['group.id'] == '' {
     fail('[Consumer] You need to specify a value for group.id')
   }
-  if $consumer_config['zookeeper.connect'] == '' {
-    fail('[Consumer] You need to specify a value for zookeeper.connect')
+  if $consumer_config['zookeeper.connect'] == '' and $consumer_config['bootstrap.servers'] == '' {
+    fail('[Consumer] You need to specify a value for consumer connection')
   }
 
   if versioncmp($kafka::version, '0.9.0.0') < 0 {


### PR DESCRIPTION
…s no longer needs to fail the run.

<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->
