### PR TITLE
[VIS-512] Apply OT changes to v5.3.0

### DIFF
--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -64,28 +64,27 @@ class kafka::broker::service(
       }
       'upstart': {
         file { "/etc/init.d/${service_name}":
-	          ensure => absent,
-	        } ~>
+	        ensure => absent,
+	      } ~>
 	
-	        exec { 'purge_rcd':
-	          command     => '/usr/sbin/update-rc.d kafka remove',
-	          refreshonly => true
-	        } ->
-	
-	        file { "${service_name}.service":
-	          ensure  => file,
-	          path    => "/etc/init/${service_name}.conf",
-	          mode    => '0755',
-	          content => template('kafka/upstart.erb')
-	        } ~>
-	        exec { "${service_name} Reload Upstart":
-	          command     => "/sbin/initctl reload-configuration",
-	          refreshonly => true,
-	          before      => Service[$service_name]
-	        }
+        exec { 'purge_rcd':
+          command     => '/usr/sbin/update-rc.d kafka remove',
+          refreshonly => true
+        } ->
+
+        file { "${service_name}.service":
+          ensure  => file,
+          path    => "/etc/init/${service_name}.conf",
+          mode    => '0755',
+          content => template('kafka/upstart.erb')
+        } ~>
+        exec { "${service_name} Reload Upstart":
+          command     => "/sbin/initctl reload-configuration",
+          refreshonly => true,
+          before      => Service[$service_name]
+        }
       }
       default: {
-	
         file { "/etc/init.d/${service_name}":
           ensure  => file,
           mode    => '0755',

--- a/manifests/broker/service.pp
+++ b/manifests/broker/service.pp
@@ -64,9 +64,9 @@ class kafka::broker::service(
       }
       'upstart': {
         file { "/etc/init.d/${service_name}":
-	        ensure => absent,
-	      } ~>
-	
+          ensure => absent,
+        } ~>
+
         exec { 'purge_rcd':
           command     => '/usr/sbin/update-rc.d kafka remove',
           refreshonly => true

--- a/manifests/mirror/config.pp
+++ b/manifests/mirror/config.pp
@@ -25,11 +25,8 @@ class kafka::mirror::config(
   if $consumer_config['group.id'] == '' {
     fail('[Consumer] You need to specify a value for group.id')
   }
-  if $consumer_config['zookeeper.connect'] == '' {
-    fail('[Consumer] You need to specify a value for zookeeper.connect')
-  }
-  if $producer_config['bootstrap.servers'] == '' {
-    fail('[Producer] You need to specify a value for bootstrap.servers')
+  if $consumer_config['zookeeper.connect'] == '' and $consumer_config['bootstrap.servers'] == '' {
+    fail('[Consumer] You need to specify a value for consumer connection')
   }
 
   class { '::kafka::consumer::config':

--- a/metadata.json
+++ b/metadata.json
@@ -21,10 +21,6 @@
       "version_requirement": ">= 4.22.0 < 5.0.0"
     },
     {
-      "name": "deric/zookeeper",
-      "version_requirement": ">= 0.5.1 < 1.0.0"
-    },
-    {
       "name": "camptocamp/systemd",
       "version_requirement": ">= 0.4.0 < 3.0.0"
     }

--- a/templates/upstart.erb
+++ b/templates/upstart.erb
@@ -1,0 +1,65 @@
+
+description "<%= @service_name %>"
+
+start on runlevel [2345]
+stop on [!12345]
+
+respawn
+respawn limit 5 60
+
+umask 007
+limit nofile 65536 65536
+limit stack 10485760 10485760
+limit core unlimited unlimited
+kill timeout 300
+
+setuid kafka
+setgid kafka
+
+script
+
+<%- case @service_name
+  when 'kafka' -%>
+
+DAEMON="/opt/kafka/bin/kafka-server-start.sh"
+DAEMON_OPTS="/opt/kafka/config/server.properties"
+
+export KAFKA_JMX_OPTS="<%= @jmx_opts %>"
+export KAFKA_LOG4J_OPTS="<%= @log4j_opts %>"
+export KAFKA_HEAP_OPTS="<%= @heap_opts %>"
+
+export KAFKA_OPTS="<%= @opts %>"
+
+<%- when 'kafka-consumer' -%>
+
+DAEMON="/opt/kafka/bin/kafka-console-consumer.sh"
+DAEMON_OPTS="<% @consumer_service_config.sort.each do |k,v| -%><% unless v.to_s.strip.empty? -%>--<%= k -%>=<%= v.is_a?(Array) ? v.join(',') : v %> <% end -%><% end -%>"
+
+export KAFKA_JMX_OPTS="<%= @consumer_jmx_opts %>"
+export KAFKA_LOG4J_OPTS="<%= @consumer_log4j_opts %>"
+
+<%- when 'kafka-mirror' -%>
+
+DAEMON="/opt/kafka/bin/kafka-run-class.sh"
+DAEMON_OPTS="kafka.tools.MirrorMaker --consumer.config <%= @consumer_config -%> --num.streams <%= @num_streams -%> --producer.config <%= @producer_config -%><%- if (scope.function_versioncmp([scope.lookupvar('kafka::version'), '0.9.0.0']) < 0) -%> --num.producers <%= @num_producers -%><%- end -%><%- if !@whitelist.eql?('') -%> --whitelist='<%= @whitelist -%>'<%- end %><%- if !@blacklist.eql?('') -%> --blacklist='<%= @blacklist -%>'<%- end -%> <%= @abort_on_send_failure_opt %>"
+
+export KAFKA_HEAP_OPTS="-Xmx<%= @max_heap -%> -Xms<%= @max_heap -%>"
+export KAFKA_JMX_OPTS="<%= @mirror_jmx_opts %>"
+export KAFKA_LOG4J_OPTS="<%= @mirror_log4j_opts %>"
+
+<%- when 'kafka-producer' -%>
+
+DAEMON="/opt/kafka/bin/kafka-console-producer.sh"
+DAEMON_OPTS="<% @producer_service_config.sort.each do |k,v| -%><% unless v.to_s.strip.empty? -%>--<%= k -%>=<%= v.is_a?(Array) ? v.join(',') : v %> <% end -%><% end -%> <%= @input -%>"
+
+export KAFKA_JMX_OPTS="<%= @producer_jmx_opts %>"
+export KAFKA_LOG4J_OPTS="<%= @producer_log4j_opts %>"
+<%- end -%>
+
+if [ -f /etc/default/kafka ]; then
+    . /etc/default/kafka
+fi
+
+exec $DAEMON $DAEMON_OPTS
+
+end script


### PR DESCRIPTION
Apply the relevant OT changes to the kafka module to version 5.3.0
(https://github.com/voxpupuli/puppet-kafka/compare/master...opentable:no-zookeeper-dep-2#diff-2f383a197b1a428561b364755701d60e)

- Don't depend on the zookeeper module
- Add an upstart script
- Fix mirror puppet logic to allow for new-style consumer
